### PR TITLE
fix: handle numeric project names in validation functions

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -126,11 +126,12 @@ export async function removeDirectory(dirPath) {
  * Validates a project path for creating a new project.
  * Enforces relative paths only and checks for invalid characters.
  *
- * @param {string} projectPath - The project path to validate
+ * @param {string|number} projectPath - The project path to validate (converted to string if needed)
  * @returns {string|null} Error message if invalid, null if valid
  */
 export function validateProjectPath(projectPath) {
-  const trimmed = projectPath.trim();
+  // Convert to string to handle numeric inputs (e.g., "1234" parsed as number by minimist)
+  const trimmed = String(projectPath).trim();
 
   // Allow current directory
   if (trimmed === '.' || trimmed === '') {
@@ -154,33 +155,38 @@ export function validateProjectPath(projectPath) {
  * Validates a project name according to npm naming conventions.
  * Returns an error message if invalid, or null if valid.
  *
- * @param {string} name - The project name to validate
+ * @param {string|number} name - The project name to validate (converted to string if needed)
  * @returns {string|null} Error message if invalid, null if valid
  */
 export function validateProjectName(name) {
-  if (!name || name.trim() === '') {
+  // Convert to string to handle numeric inputs (e.g., "1234" parsed as number by minimist)
+  const nameStr = String(name);
+
+  if (!nameStr || nameStr.trim() === '') {
     return 'Project name cannot be empty';
   }
 
+  const trimmed = nameStr.trim();
+
   // Check for spaces
-  if (name.includes(' ')) {
+  if (trimmed.includes(' ')) {
     return 'Project name cannot contain spaces. Use hyphens or underscores instead (e.g., "my-sketch")';
   }
 
   // Check for invalid characters (only allow alphanumeric, hyphen, underscore, dot)
-  if (!/^[a-zA-Z0-9._-]+$/.test(name)) {
+  if (!/^[a-zA-Z0-9._-]+$/.test(trimmed)) {
     return 'Project name can only contain letters, numbers, hyphens, underscores, and dots';
   }
 
   // Check if starts with dot or hyphen
-  if (name.startsWith('.') || name.startsWith('-')) {
+  if (trimmed.startsWith('.') || trimmed.startsWith('-')) {
     return 'Project name cannot start with a dot or hyphen';
   }
 
   // Check for reserved names
   const reservedNames = ['node_modules', 'package.json', 'package-lock.json'];
-  if (reservedNames.includes(name.toLowerCase())) {
-    return `"${name}" is a reserved name and cannot be used`;
+  if (reservedNames.includes(trimmed.toLowerCase())) {
+    return `"${trimmed}" is a reserved name and cannot be used`;
   }
 
   return null; // Valid

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { validateProjectName, validateTemplate, validateMode, validateVersion } from '../src/utils.js';
+import { validateProjectName, validateProjectPath, validateTemplate, validateMode, validateVersion } from '../src/utils.js';
 
 describe('utils validations', () => {
   it('validateProjectName rejects empty and invalid names', () => {
@@ -7,6 +7,19 @@ describe('utils validations', () => {
     expect(validateProjectName('my project')).toBeTruthy();
     expect(validateProjectName('.hidden')).toBeTruthy();
     expect(validateProjectName('good-name')).toBeNull();
+  });
+
+  it('validateProjectName handles numeric inputs', () => {
+    // Numeric inputs should be converted to strings and validated
+    expect(validateProjectName(1234)).toBeNull(); // Valid: "1234"
+    expect(validateProjectName(42)).toBeNull(); // Valid: "42"
+    expect(validateProjectName(0)).toBeNull(); // Valid: "0" is a valid name
+  });
+
+  it('validateProjectPath handles numeric inputs', () => {
+    // Numeric inputs should be converted to strings and validated
+    expect(validateProjectPath(1234)).toBeNull(); // Valid: "1234" is a relative path
+    expect(validateProjectPath(42)).toBeNull(); // Valid: "42" is a relative path
   });
 
   it('validateTemplate accepts known templates', () => {


### PR DESCRIPTION
When running `npx create-p5 1234`, minimist parses numeric arguments as numbers instead of strings, causing validateProjectName() to crash when calling .trim() on a number.

This commit fixes the issue by:
- Converting inputs to strings in validateProjectName()
- Converting inputs to strings in validateProjectPath()
- Adding test cases for numeric inputs

Fixes #3