### PR TITLE
Download only `p5.d.ts` for instance mode, or both `global.d.ts` and `p5.d.ts` for global mode templates.

### DIFF
--- a/index.js
+++ b/index.js
@@ -358,9 +358,9 @@ EXAMPLES:
       try {
         if (args.verbose) {
           const typesSpinner = startSpinner('Downloading TypeScript definitions');
-          typeDefsVersion = await downloadTypeDefinitions(selectedVersion, typesPath, typesSpinner);
+          typeDefsVersion = await downloadTypeDefinitions(selectedVersion, typesPath, typesSpinner, selectedTemplate);
         } else {
-          typeDefsVersion = await downloadTypeDefinitions(selectedVersion, typesPath);
+          typeDefsVersion = await downloadTypeDefinitions(selectedVersion, typesPath, null, selectedTemplate);
         }
       } catch (error) {
         p.log.warn(error.message);

--- a/src/update.js
+++ b/src/update.js
@@ -131,7 +131,7 @@ async function updateVersion(projectDir, config, options = {}) {
   // Update TypeScript definitions
   const typesPath = path.join(projectDir, 'types');
   await createDirectory(typesPath);
-  const typeDefsVersion = await downloadTypeDefinitions(newVersion, typesPath);
+  const typeDefsVersion = await downloadTypeDefinitions(newVersion, typesPath, null, config.template);
   console.log(`✓ Updated TypeScript definitions to version ${typeDefsVersion}`);
 
   // Update p5-config.json

--- a/src/version.js
+++ b/src/version.js
@@ -104,22 +104,28 @@ export async function downloadP5Files(version, targetDir, spinner = null) {
 
 /**
  * Downloads TypeScript type definitions for p5.js from jsdelivr CDN.
- * Downloads both global.d.ts and p5.d.ts as global.d.ts imports from p5.d.ts.
+ * For instance-mode sketches, downloads only p5.d.ts.
+ * For global-mode sketches, downloads both global.d.ts and p5.d.ts.
  * Falls back to the latest version if the specified version's types are not found.
  * @param {string} version - The p5.js version to download type definitions for
  * @param {string} targetDir - The directory path where type definitions should be saved
  * @param {Object} [spinner] - Optional spinner object with stop() method for progress feedback
+ * @param {string} [template] - The template being used ('instance', 'basic', 'typescript', 'empty')
  * @returns {Promise<string>} The actual version of the type definitions downloaded
  * @throws {Error} If download fails or files cannot be written
  */
-export async function downloadTypeDefinitions(version, targetDir, spinner = null) {
+export async function downloadTypeDefinitions(version, targetDir, spinner = null, template = null) {
   const cdnBase = 'https://cdn.jsdelivr.net/npm';
 
-  // Define both files that need to be downloaded
-  const typeFiles = [
-    { name: 'global.d.ts', url: `${cdnBase}/p5@${version}/types/global.d.ts` },
-    { name: 'p5.d.ts', url: `${cdnBase}/p5@${version}/types/p5.d.ts` }
-  ];
+  // Determine which files to download based on template
+  // Instance mode only needs p5.d.ts, global mode needs both
+  const isInstanceMode = template === 'instance';
+  const typeFiles = isInstanceMode
+    ? [{ name: 'p5.d.ts', url: `${cdnBase}/p5@${version}/types/p5.d.ts` }]
+    : [
+        { name: 'global.d.ts', url: `${cdnBase}/p5@${version}/types/global.d.ts` },
+        { name: 'p5.d.ts', url: `${cdnBase}/p5@${version}/types/p5.d.ts` }
+      ];
 
   try {
     if (spinner) {

--- a/tests/version.types.test.js
+++ b/tests/version.types.test.js
@@ -46,7 +46,55 @@ describe('downloadTypeDefinitions fallback', () => {
     const actual = await downloadTypeDefinitions('0.0.1', tmpDir);
     expect(actual).toBe('1.9.0');
 
-    // Verify both global.d.ts and p5.d.ts are downloaded
+    // Verify both global.d.ts and p5.d.ts are downloaded for global mode (default)
+    const globalFileExists = await fs.stat(path.join(tmpDir, 'global.d.ts'))
+      .then(() => true)
+      .catch(() => false);
+
+    const p5FileExists = await fs.stat(path.join(tmpDir, 'p5.d.ts'))
+      .then(() => true)
+      .catch(() => false);
+
+    expect(globalFileExists).toBe(true);
+    expect(p5FileExists).toBe(true);
+  });
+
+  it('downloads only p5.d.ts for instance mode template', async () => {
+    globalThis.fetch = async (url) => {
+      return {
+        ok: true,
+        text: async () => '// dummy types'
+      };
+    };
+
+    const actual = await downloadTypeDefinitions('1.9.0', tmpDir, null, 'instance');
+    expect(actual).toBe('1.9.0');
+
+    // Verify only p5.d.ts is downloaded for instance mode
+    const globalFileExists = await fs.stat(path.join(tmpDir, 'global.d.ts'))
+      .then(() => true)
+      .catch(() => false);
+
+    const p5FileExists = await fs.stat(path.join(tmpDir, 'p5.d.ts'))
+      .then(() => true)
+      .catch(() => false);
+
+    expect(globalFileExists).toBe(false);
+    expect(p5FileExists).toBe(true);
+  });
+
+  it('downloads both files for basic template', async () => {
+    globalThis.fetch = async (url) => {
+      return {
+        ok: true,
+        text: async () => '// dummy types'
+      };
+    };
+
+    const actual = await downloadTypeDefinitions('1.9.0', tmpDir, null, 'basic');
+    expect(actual).toBe('1.9.0');
+
+    // Verify both files are downloaded for basic (global mode) template
     const globalFileExists = await fs.stat(path.join(tmpDir, 'global.d.ts'))
       .then(() => true)
       .catch(() => false);


### PR DESCRIPTION
Download only `p5.d.ts` for instance mode, or both `global.d.ts` and `p5.d.ts` for global mode templates.
  
Fixes #1 