### PR TITLE
Add checkJs option to jsconfig.json files

### DIFF
--- a/docs/PRODUCT_REQUIREMENTS.md
+++ b/docs/PRODUCT_REQUIREMENTS.md
@@ -872,7 +872,8 @@ canvas {
 ```json
 {
   "compilerOptions": {
-    "target": "ES6"
+    "target": "ES6",
+    "checkJs": false
   },
   "include": [
     "*.js",

--- a/templates/basic/jsconfig.json
+++ b/templates/basic/jsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
-    "target": "ES6"
+    "target": "ES6",
+    "checkJs": false // Enable type checking for JavaScript files
   },
   "include": [
     "*.js",

--- a/templates/empty/jsconfig.json
+++ b/templates/empty/jsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
-    "target": "ES6"
+    "target": "ES6",
+    "checkJs": false // Enable type checking for JavaScript files
   },
   "include": [
     "*.js",

--- a/templates/instance/jsconfig.json
+++ b/templates/instance/jsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
-    "target": "ES6"
+    "target": "ES6",
+    "checkJs": false // Enable type checking for JavaScript files
   },
   "include": [
     "*.js",


### PR DESCRIPTION
Added "checkJs": false to jsconfig.json in basic, empty, and instance templates, as well as the documentation example.

Fixes #2 