### PR TITLE
Have jsconfig.json include ALL js files recursively (not just siblings)

### DIFF
--- a/templates/basic-global-js/jsconfig.json
+++ b/templates/basic-global-js/jsconfig.json
@@ -4,7 +4,7 @@
     "checkJs": false // Enable type checking for JavaScript files
   },
   "include": [
-    "*.js",
+    "**/*.js",
     "types/*.d.ts"
   ]
 }

--- a/templates/basic-instance-js/jsconfig.json
+++ b/templates/basic-instance-js/jsconfig.json
@@ -4,7 +4,7 @@
     "checkJs": false // Enable type checking for JavaScript files
   },
   "include": [
-    "*.js",
+    "**/*.js",
     "types/*.d.ts"
   ]
 }


### PR DESCRIPTION
At the moment, the templates' `jsconfig.json` files include in their projects only `*.js` i.e. javascript files in the same dir.

As it stands with this, vscode won't type-check any js files in any subdir. e.g. in `src/sketch.js` or in `particles/index.js`

I've changed this to look also in any subdir using `**/*.js`

Affects templates basic-global-js and basic-instance-js.  I've tested both.
 
Arguably, we could include files with other appropriate extensions, too, (mjs?) but anyone using with those can likely debug their own jsconfig just fine, and I think it's useful to keep the default config file as simple as possible for readability / avoiding invoking terror.
