### PR TITLE
Skip permission error test on Windows

### DIFF
--- a/tests/configMigration.test.js
+++ b/tests/configMigration.test.js
@@ -79,7 +79,7 @@ describe('Config file migration', () => {
     expect(newContentResult.version).toBe('2.0.0');
   });
 
-  it('handles permission errors gracefully', async () => {
+  it.skipIf(process.platform === 'win32')('handles permission errors gracefully', async () => {
     // Setup: create old config file
     await fs.writeFile(oldConfigPath, JSON.stringify(testConfig, null, 2));
 


### PR DESCRIPTION
The test for handling permission errors is now skipped on Windows platforms using it.skipIf(process.platform === 'win32') to avoid platform-specific issues.

Fixes #48 