### PR TITLE
add mermaid flow diagram for scaffold process

### DIFF
--- a/FLOW-DIAGRAM.md
+++ b/FLOW-DIAGRAM.md
@@ -1,0 +1,31 @@
+Here is a flowchart of the process in scaffold.
+
+Warning: This may well be out of date - last revised from scaffold.js on 2025-12-20
+
+```mermaid
+    flowchart TD
+    
+    intro[Intro] --> determinePath[Determine Project Path]
+    determinePath --> determineSetupType[Determine Setup Type <br>basic / standard / custom]
+    determineSetupType --> isCTemplate{is Custom<br>Template?}
+    isCTemplate --> |yes| handleCustomTemplate[Handle Custom Template]
+    isCTemplate --> |no|determineP5Version[Determine p5 Version]
+    handleCustomTemplate --> exit[exit];
+    determineP5Version --> determineDeliveryMode[Determine Delivery Mode]
+    determineDeliveryMode --> determineLanguageAndP5Mode[Determine Language <br>and P5 Mode]
+    determineLanguageAndP5Mode --> showSummary
+    showSummary[Show Summary] --> copyTemplateFiles    
+    copyTemplateFiles[Copy Template Files] --> isUseGit{Use git?}
+    isUseGit --> |yes| initGitRepo
+    isUseGit --> |no| isLocalDeliveryMode{is Local <br>Delivery?}
+    initGitRepo[Init Git Repo] --> isLocalDeliveryMode    
+    isLocalDeliveryMode --> |yes| dloadP5Library 
+    isLocalDeliveryMode --> |no| injectScriptTag
+    dloadP5Library[Download p5 Library] --> injectScriptTag    
+    injectScriptTag[Inject Script Tag] --> isDloadTypeDecls{Type decls<br>wanted?}
+    isDloadTypeDecls --> |yes|dloadTypeDecls[Download Type Declarations]
+    isDloadTypeDecls --> |no|showSummaryAndNextSteps[Summary and<br>Next Steps]
+    dloadTypeDecls --> showSummaryAndNextSteps
+    showSummaryAndNextSteps --> cleanUp[Clean up]
+    cleanUp --> exit2[Exit]
+```


### PR DESCRIPTION
For developers, I added a FLOW-DIAGRAM.md containing a mermaid flow diagram.  This is a text declaration of a flow which renders on github (and gist) as a diagram.  

Tool support: there also exist vscode extensions which support preview while editing - I haven't used them but I use [this official online editor tool instead](https://mermaid.live/edit)

Diagrams that aren't generated directly from the actual source are notorious for going out of date.  If we notice it going out of date and not being maintained, we can delete it, I don't mind.  Even if it's only useful for a week, that's still great - I produced this anyway just as a product of reviewing the code to help me reason about the typescript template.