### PR TITLE
setup typescript project for selected p5Mode at run-time

### DIFF
--- a/src/operations/scaffold.js
+++ b/src/operations/scaffold.js
@@ -16,7 +16,7 @@ import * as display from '../ui/display.js';
 import * as prompts from '../ui/prompts.js';
 
 // Business utilities
-import { copyTemplateFiles, determineTargetPath, validateProjectName, directoryExists, validateMode, validateVersion, validateLanguage, validateP5Mode, validateSetupType, getTemplateName, generateProjectName, isRemoteTemplateSpec } from '../utils.js';
+import { copyTemplateFiles, determineTargetPath, validateProjectName, directoryExists, validateMode, validateVersion, validateLanguage, validateP5Mode, validateSetupType, getTemplateName, generateProjectName, isRemoteTemplateSpec, renameFile, deleteFile } from '../utils.js';
 import { fetchVersions, downloadP5Files, downloadTypeDefinitions } from '../version.js';
 import { injectP5Script } from '../htmlManager.js';
 import { createConfig } from '../config.js';
@@ -380,6 +380,24 @@ export async function scaffold(args) {
       const htmlContent = await fs.readFile(indexPath, 'utf-8');
       const updatedHtml = injectP5Script(htmlContent, selectedVersion, selectedDeliveryMode);
       await fs.writeFile(indexPath, updatedHtml, 'utf-8');
+    }
+    //STEP: set up basic-ts typescript template for selected p5Mode (global / instance)
+    if (selectedLanguage === 'typescript'){
+      //Within the newly created project folder...
+      //  rename either sketchGlobalMode.ts or sketchInstanceMode.ts to sketch.ts
+      //  delete the other
+      const targetSketchName = "sketch.ts"
+      const globalModeSourceSketch = "sketchGlobalMode.ts"
+      const instanceModeSourceSketch = "sketchInstanceMode.ts"
+      
+      const [sourceSketchName, unusedSketchName] = selectedP5Mode === "global" ? 
+      [globalModeSourceSketch, instanceModeSourceSketch] : 
+      [instanceModeSourceSketch, globalModeSourceSketch]
+      
+      renameFile(path.join(targetPath, "src", sourceSketchName), 
+                 path.join(targetPath, "src", targetSketchName));
+                 
+      deleteFile(path.join(targetPath, "src", unusedSketchName))
     }
     // STEP: Download TypeScript definitions (skip for basic setup)
     let typeDefsVersion = null;

--- a/src/utils.js
+++ b/src/utils.js
@@ -54,6 +54,22 @@ export async function createDirectory(dirPath) {
 export async function copyFile(source, dest) {
   await fs.copyFile(source, dest);
 }
+/**
+ * Rename/move a single file from source to destination
+ * @param {string} sourcePath
+ * @param {string} destPath
+ */
+export async function renameFile(sourcePath, destPath) {
+  await fs.rename(sourcePath, destPath);
+}
+
+/**
+ * Delete file at given path
+ * @param {string} targetFilePath
+ */
+export async function deleteFile(targetFilePath) {
+  await fs.unlink(targetFilePath);
+}
 
 /**
  * Check if a file or directory exists

--- a/templates/basic-ts/README.md
+++ b/templates/basic-ts/README.md
@@ -15,16 +15,6 @@ npm i
 npm run dev
 ```
 
-### Choose global-mode or instance-mode p5.js
-
-Two sketches are provided in src, one for each mode.
-
-If you're not sure, use global mode.
-
-Delete whichever of the two you don't need - this is important for correct type-checking operation.
-
-Ensure index.html is pointing at the right one.
-
 ### (optional) Type-check ALL your files
 
 You can type-check _all_ your files from the command-line, with:

--- a/templates/basic-ts/index.html
+++ b/templates/basic-ts/index.html
@@ -7,8 +7,6 @@
         <link rel="stylesheet" href="/src/style.css" />
     </head>
     <body>
-        <script type="module" src="/src/sketchGlobalMode.ts"></script>
-        <!-- or -->
-        <!-- <script type="module" src="/src/sketchInstanceMode.ts"></script> -->
+        <script type="module" src="/src/sketch.ts"></script>
     </body>
 </html>


### PR DESCRIPTION
For typescript, global/instance sketch setup is now fully automated based on the user's install choices.

Also updated (simplified) readme accordingly.

This addresses a couple of questions you had in #56,  [here](https://github.com/SableRaf/create-p5/pull/56#discussion_r2637716479) and [here](https://github.com/SableRaf/create-p5/pull/56#discussion_r2637716554)
