### PR TITLE
Get package version information in the right places

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ import { update } from './src/operations/update.js';
 import { configExists, migrateConfigIfNeeded } from './src/config.js';
 import { t } from './src/i18n/index.js';
 import * as display from './src/ui/display.js';
+import { VERSION } from './src/version.js';
 
 async function main() {
   // Parse command line arguments
@@ -33,6 +34,12 @@ async function main() {
   if (args.silent) {
     args.yes = true;
     display.setSilentMode(true);
+  }
+
+  // Handle --version flag (when used without a value)
+  if (args.version === true || (args.version === '' && !args._.length)) {
+    console.log(VERSION);
+    process.exit(0);
   }
 
   // Handle --help flag

--- a/src/ui/display.js
+++ b/src/ui/display.js
@@ -7,15 +7,7 @@
 import * as p from '@clack/prompts';
 import { blue, red, green, cyan, bgMagenta, white, gray } from 'kolorist';
 import { t } from '../i18n/index.js';
-import { readFileSync } from 'node:fs';
-import { fileURLToPath } from 'node:url';
-import { dirname, join } from 'node:path';
-
-const __dirname = dirname(fileURLToPath(import.meta.url));
-const packageJson = JSON.parse(
-  readFileSync(join(__dirname, '../../package.json'), 'utf-8')
-);
-const VERSION = packageJson.version;
+import { VERSION } from '../version.js';
 
 let silentModeEnabled = false;
 

--- a/src/ui/display.js
+++ b/src/ui/display.js
@@ -5,8 +5,17 @@
  */
 
 import * as p from '@clack/prompts';
-import { blue, red, green, cyan, bgMagenta, white } from 'kolorist';
+import { blue, red, green, cyan, bgMagenta, white, gray } from 'kolorist';
 import { t } from '../i18n/index.js';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const packageJson = JSON.parse(
+  readFileSync(join(__dirname, '../../package.json'), 'utf-8')
+);
+const VERSION = packageJson.version;
 
 let silentModeEnabled = false;
 
@@ -52,7 +61,7 @@ export function intro() {
   if (shouldSuppress('intro')) {
     return;
   }
-  p.intro(bgMagenta(white(t('cli.intro'))));
+  p.intro(bgMagenta(white(t('cli.intro'))) + ' ' + gray(`v${VERSION}`));
 }
 
 /**

--- a/src/utils.js
+++ b/src/utils.js
@@ -3,7 +3,10 @@
  */
 
 import fs from 'fs/promises';
+import { readFileSync } from 'fs';
 import path from 'path';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
 import { uniqueNamesGenerator, adjectives, colors, animals } from 'unique-names-generator';
 
 /**
@@ -445,13 +448,27 @@ export function determineTargetPath(cwdPath, projectPath){
   return platformPath.join(cwdPath, projectPath);
 }
 
-/** Return path.win32 or path.posix by guessing based on the given array of example path strings. 
+/** Return path.win32 or path.posix by guessing based on the given array of example path strings.
  * This is a guess but is only for use when unit testing.
  * @param {string[]} examplePaths
  * @returns {path.PlatformPath}
  */
 function getOSPlatformPathModuleBasedOnExamples(examplePaths){
  return examplePaths.some(p => p.includes('\\') || p.includes(':'))
-    ? path.win32 
+    ? path.win32
     : path.posix;
+}
+
+/**
+ * Reads and returns the version from package.json
+ * @returns {string} The current version of create-p5 CLI tool
+ */
+export function getPackageVersion() {
+  const __filename = fileURLToPath(import.meta.url);
+  const __dirname = dirname(__filename);
+  const packageJson = JSON.parse(
+    readFileSync(join(__dirname, '../package.json'), 'utf-8')
+  );
+
+  return packageJson.version;
 }

--- a/src/version.js
+++ b/src/version.js
@@ -1,5 +1,10 @@
-import { writeFile } from './utils.js';
+import { writeFile, getPackageVersion } from './utils.js';
 import { t } from './i18n/index.js';
+
+/**
+ * The current version of create-p5 CLI tool from package.json
+ */
+export const VERSION = getPackageVersion();
 
 /**
  * Checks if a version string is a stable release (semver compliant: X.Y.Z)


### PR DESCRIPTION
- Log version in the intro of the dialog flow
- Log package version when using `--version` with no argument

<img width="536" height="171" alt="image" src="https://github.com/user-attachments/assets/17eba04d-1b27-43cd-84e9-7760a7d89f47" />

Note: these changes should be backwards compatible with `--version <p5js-version>`

Fixes #21 